### PR TITLE
feat(auth): oauth2 로그인 시 토큰 발급

### DIFF
--- a/src/main/java/com/hppystay/hotelreservation/auth/config/PermitAllPath.java
+++ b/src/main/java/com/hppystay/hotelreservation/auth/config/PermitAllPath.java
@@ -11,6 +11,8 @@ public class PermitAllPath {
             "/api/auth/password/reset",
             "/api/auth/password/change",
 
+            "/api/oauth2/get-token",
+
             // toss 인증 관련 api (채운 작성)
             "/toss/**",
             "/payments/**",
@@ -40,7 +42,7 @@ public class PermitAllPath {
 
             // View
             "/login",
-            "/sign-up"
-
+            "/sign-up",
+            "/token/callback"
     };
 }

--- a/src/main/java/com/hppystay/hotelreservation/auth/config/RedisConfig.java
+++ b/src/main/java/com/hppystay/hotelreservation/auth/config/RedisConfig.java
@@ -1,0 +1,10 @@
+package com.hppystay.hotelreservation.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+}

--- a/src/main/java/com/hppystay/hotelreservation/auth/controller/TestController.java
+++ b/src/main/java/com/hppystay/hotelreservation/auth/controller/TestController.java
@@ -3,19 +3,38 @@ package com.hppystay.hotelreservation.auth.controller;
 import com.hppystay.hotelreservation.auth.jwt.JwtTokenUtils;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.TimeUnit;
 
 @RestController
 @RequestMapping("/test")
 @RequiredArgsConstructor
 public class TestController {
     private final JwtTokenUtils jwtTokenUtils;
+    private final StringRedisTemplate redisTemplate;
 
     @GetMapping("/token")
-    public Claims val(@RequestParam("token") String jwt) {
-        return jwtTokenUtils.parseClaims(jwt);
+    public Claims val(@RequestParam("token") String token) {
+        return jwtTokenUtils.parseClaims(token);
+    }
+
+    @GetMapping("/uuid")
+    public String uuid(@RequestParam("uuid") String uuid) {
+        return redisTemplate.opsForValue().get(uuid);
+    }
+
+    @GetMapping("/redis")
+    public String test() {
+        ValueOperations<String, String> operations
+                = redisTemplate.opsForValue();
+
+        operations.set("토큰", "리프레시 토큰", 10, TimeUnit.SECONDS);
+        return "test";
     }
 }

--- a/src/main/java/com/hppystay/hotelreservation/auth/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/hppystay/hotelreservation/auth/jwt/JwtTokenUtils.java
@@ -30,7 +30,20 @@ public class JwtTokenUtils {
                 .build();
     }
 
-    public String generateToken(Member member) {
+    public String generateAccessToken(Member member) {
+        Instant now = Instant.now();
+        Claims jwtClaims = Jwts.claims()
+                .setSubject(member.getEmail())
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plusSeconds(60 * 5)));
+
+        return Jwts.builder()
+                .setClaims(jwtClaims)
+                .signWith(this.siginingKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(Member member) {
         Instant now = Instant.now();
         Claims jwtClaims = Jwts.claims()
                 .setSubject(member.getEmail())

--- a/src/main/java/com/hppystay/hotelreservation/auth/oauth2/OAuth2Controller.java
+++ b/src/main/java/com/hppystay/hotelreservation/auth/oauth2/OAuth2Controller.java
@@ -1,0 +1,25 @@
+package com.hppystay.hotelreservation.auth.oauth2;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth2")
+public class OAuth2Controller {
+    private final OAuth2UserService oAuth2UserService;
+
+    @GetMapping("/get-token")
+    public TokenDto getAccessToken(
+            @RequestParam("uuid")
+            String uuid
+    ) {
+        return oAuth2UserService.getAccessToken(uuid);
+    }
+}

--- a/src/main/java/com/hppystay/hotelreservation/auth/oauth2/OAuth2UserService.java
+++ b/src/main/java/com/hppystay/hotelreservation/auth/oauth2/OAuth2UserService.java
@@ -1,6 +1,8 @@
 package com.hppystay.hotelreservation.auth.oauth2;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -15,7 +17,10 @@ import java.util.Map;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class OAuth2UserService extends DefaultOAuth2UserService {
+    private final StringRedisTemplate stringRedisTemplate;
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
@@ -63,5 +68,12 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
                 attributes,
                 nameAttribute
         );
+    }
+
+    public TokenDto getAccessToken(String uuid) {
+        // TODO 인증 시간 만료 에러
+        String accessToken = stringRedisTemplate.opsForValue().get(uuid);
+        log.info(accessToken);
+        return new TokenDto(accessToken);
     }
 }

--- a/src/main/java/com/hppystay/hotelreservation/auth/oauth2/TokenDto.java
+++ b/src/main/java/com/hppystay/hotelreservation/auth/oauth2/TokenDto.java
@@ -1,0 +1,14 @@
+package com.hppystay.hotelreservation.auth.oauth2;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenDto {
+    private String accessToken;
+}

--- a/src/main/java/com/hppystay/hotelreservation/auth/service/MemberService.java
+++ b/src/main/java/com/hppystay/hotelreservation/auth/service/MemberService.java
@@ -87,7 +87,7 @@ public class MemberService implements UserDetailsService {
         if (!passwordEncoder.matches(dto.getPassword(), member.getPassword()))
             throw new GlobalException(GlobalErrorCode.EMAIL_PASSWORD_MISMATCH);
 
-        String jwt = jwtTokenUtils.generateToken(member);
+        String jwt = jwtTokenUtils.generateAccessToken(member);
         JwtResponseDto response = new JwtResponseDto();
         response.setToken(jwt);
 

--- a/src/main/java/com/hppystay/hotelreservation/view/ViewController.java
+++ b/src/main/java/com/hppystay/hotelreservation/view/ViewController.java
@@ -2,7 +2,7 @@ package com.hppystay.hotelreservation.view;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class ViewController {
@@ -16,8 +16,11 @@ public class ViewController {
         return "sign-up";
     }
 
-    @GetMapping("/oauth2/callback")
-    public String oAuthCallback() {
+    @GetMapping("/token/callback")
+    public String oAuthCallback(
+            @RequestParam("uuid")
+            String uuid
+    ) {
         return "oauth-redirect";
     }
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>로그인 화면</title>
 </head>
 <body>
 <!-- login.html 어디에든 -->

--- a/src/main/resources/templates/oauth-redirect.html
+++ b/src/main/resources/templates/oauth-redirect.html
@@ -2,17 +2,30 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>oauth2 redirect</title>
 </head>
 <body>
-
-<script>
-    const queryParams = new URLSearchParams(window.location.search);
-    const token = queryParams.get('token');
-
-    localStorage.setItem('token', token);
-
-    window.location.hash='/';
-</script>
 </body>
+<script>
+    function fetchAccessToken() {
+        const queryParams = new URLSearchParams(window.location.search);
+        const uuid = queryParams.get('uuid');
+
+        fetch(`/api/oauth2/get-token?uuid=${uuid}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }).then(response => {
+            return response.json();
+        }).then(data => {
+            localStorage.setItem('token', data.accessToken);
+            alert('로그인 성공');
+            // 임시로 로그인 페이지로 이동
+            location.href = "/login";
+        })
+    }
+
+    fetchAccessToken();
+</script>
 </html>


### PR DESCRIPTION
oauth 계정 생성후 사용자에게 리다이렉션 시키면서 accessToken을 넘기는 부분은
토큰을 바로 넘기는게 아니라 랜덤 UUID를 만들어 redis에 Ket, Value쌍으로 accessToken을 저장해
간접적으로 전달하도록 변경했습니다.(60초간 유효)

그 후 api로 요청을 보내 accessToken을 받아와 LocalStroage에 저장하고

RefreshToken은 일단 Cookie에 저장하도록 설정했습니다.